### PR TITLE
(Fix) Remove redundant 'gsed' dependency check

### DIFF
--- a/umbrel-dev
+++ b/umbrel-dev
@@ -38,7 +38,7 @@ fi
 # Check required dependencies are installed
 # If not, fail with instructions on how to fix
 check_dependencies() {
-  for cmd in "gsed" "git" "vagrant" "vboxmanage"; do
+  for cmd in "git" "vagrant" "vboxmanage"; do
     if ! command -v $cmd >/dev/null 2>&1; then
       echo "This script requires Git, VirtualBox and Vagrant to be installed."
       echo


### PR DESCRIPTION
### Description

`gsed` isn't present on Linux and causes `check_dependencies` to fail. This PR removes the check which should be fine for Linux machines since `sed` is pretty standard and should still be ok for MacOS because the `gsed` dependency is already checked a few lines above this change.

(If missing `sed` becomes an issue later on for Linux users, we can also create a `sed` check-and-install like you guys did for `gsed` and MacOS)

_Helps to address **Issue #4**, I was able to successfully complete `$ umbrel-dev init` after this change on an Ubuntu 18.04 system_