### PR TITLE
Update brew install cask command

### DIFF
--- a/umbrel-dev
+++ b/umbrel-dev
@@ -47,7 +47,7 @@ check_dependencies() {
       echo "If you use Homebrew you can install them with:"
       echo
       echo "  brew install git"
-      echo "  brew cask install virtualbox vagrant"
+      echo "  brew install --cask virtualbox vagrant"
       echo
       echo "Otherwise see:"
       echo


### PR DESCRIPTION
As of Homebrew v2.6.0, [all `brew cask` commands have been deprecated in favour of `brew` commands (with `--cask`) when necessary](https://brew.sh/2020/12/01/homebrew-2.6.0/).