### PR TITLE
Set NETWORK to regtest before calling start script

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -71,7 +71,7 @@ Vagrant.configure(2) do |config|
     cd /vagrant/getumbrel/umbrel
     sudo chown -R 1000:1000 .
     chmod -R 700 tor/data/*
-    ./scripts/start
+    NETWORK=regtest ./scripts/start
   SHELL
 
   # Message


### PR DESCRIPTION
Added `NETWORK=regtest` before the execution the the `start` script in the vagrant provision script.

 This will allow to always run on regtest. Now, if you delete the `statutes/configured` file before the VM boot, it will reconfigure Umbrel before starting it. 