### PR TITLE
Update Linux kernel and headers on first boot

### DIFF
--- a/umbrel-dev
+++ b/umbrel-dev
@@ -138,6 +138,13 @@ fi
 # Boot the development VM
 if [[ "$command" = "boot" ]]; then
   check_umbrel_dev_environment
+
+  # Update some packages on boot to prevent issues with vagrant-vbguest.
+  # https://github.com/dotless-de/vagrant-vbguest/issues/351#issuecomment-545391139
+  vagrant up --no-provision || true # This will sometimes fail
+  vagrant ssh -c "sudo apt-get update -y && sudo apt-get install -y build-essential linux-headers-amd64 linux-image-amd64 python-pip"
+  vagrant halt
+
   vagrant up
   exit
 fi


### PR DESCRIPTION
The `vagrant-vbguest` plugin installs the Linux headers for the currently installed kernel version with:

```
apt-get install -y linux-headers-`uname -r`
```

This fails if the Vagrant box is running a slightly old kernel once it's headers have been removed from the Debian apt repository.

So instead, we manually install the latest kernel and headers on first boot, then restart and everything works correctly.