### PR TITLE
Install Docker Compose via pip3

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -45,11 +45,10 @@ Vagrant.configure(2) do |config|
 
   # Install Docker
   config.vm.provision "shell", inline: <<-SHELL
-    sudo apt-get install -y curl
+    sudo apt-get install -y curl python3-pip
     curl -fsSL https://get.docker.com | sudo sh
     sudo usermod -aG docker vagrant
-    sudo curl -L "https://github.com/docker/compose/releases/download/1.27.4/docker-compose-$(uname -s)-$(uname -m)" -o /usr/local/bin/docker-compose
-    sudo chmod +x /usr/local/bin/docker-compose
+    pip3 install docker-compose
   SHELL
 
   # Install Avahi

--- a/docker-compose.override.yml
+++ b/docker-compose.override.yml
@@ -2,12 +2,15 @@ version: '3.7'
 
 services:
         dashboard:
+                image: getumbrel/dashboard
                 build:
                   context: ../umbrel-dashboard
                   dockerfile: Dockerfile.dev
                 volumes:
                   - ../umbrel-dashboard:/app
         manager:
+                image: getumbrel/manager
                 build: ../umbrel-manager
         middleware:
+                image: getumbrel/middleware
                 build: ../umbrel-middleware

--- a/umbrel-dev
+++ b/umbrel-dev
@@ -138,6 +138,13 @@ fi
 # Boot the development VM
 if [[ "$command" = "boot" ]]; then
   check_umbrel_dev_environment
+
+  # Update some packages on boot to prevent issues with vagrant-vbguest.
+  # https://github.com/dotless-de/vagrant-vbguest/issues/351#issuecomment-545391139
+  vagrant up --no-provision || true # This will sometimes fail
+  vagrant ssh -c "sudo apt-get update -y && sudo apt-get install -y build-essential linux-headers-amd64 linux-image-amd64 python-pip"
+  vagrant halt
+
   vagrant up
   exit
 fi


### PR DESCRIPTION
We were installing a fixed version of docker-compose but the latest version of Docker which was causing issues. This PR installs docker-compose via pip3 which is kept up to date with the latest release.

We now also strip out the checksum pins from the image properties of containers that are built from source, since that isn't allowed in newer versions of docker-compose.