### PR TITLE
Parallels

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -25,24 +25,15 @@ Vagrant.configure(2) do |config|
 
   # Setup VM
   config.vm.define "umbrel-dev"
-  config.vm.box = "bento/debian-10"
+  config.vm.box = "avi0xff/debian10-arm64"
   config.vm.hostname = "umbrel-dev"
   config.vm.network "public_network", bridge: "en0: Wi-Fi (AirPort)"
-  config.vm.synced_folder ".", "/vagrant"
+  config.vm.synced_folder ".", "/vagrant", type: "sshfs", sshfs_opts_append: "-o cache=no"
 
   # Configure VM resources
-  config.vm.provider "virtualbox" do |vb, override|
-    # Install required plugins
-    # config.vagrant.plugins = {"vagrant-vbguest" => {"version" => "0.24.0"}}
-    # config.vm.synced_folder ".", "/vagrant", type: "virtualbox"
-
-    vb.customize ["modifyvm", :id, "--cpus", "2"]
-    vb.customize ["modifyvm", :id, "--memory", "2048"]
-  end
-
-  config.vm.provider "parallels" do |prl|
-    prl.cpus = 2
-    prl.memory = 2048
+  config.vm.provider "parallels" do |parallels|
+    parallels.cpus = 2
+    parallels.memory = 4096
   end
 
   # Update package lists
@@ -52,7 +43,7 @@ Vagrant.configure(2) do |config|
 
   # Install Docker
   config.vm.provision "shell", inline: <<-SHELL
-    sudo apt-get install -y curl python3-pip
+    sudo apt-get install -y curl python3-pip libffi-dev
     curl -fsSL https://get.docker.com | sudo sh
     sudo usermod -aG docker vagrant
     pip3 install docker-compose
@@ -75,9 +66,9 @@ Vagrant.configure(2) do |config|
   # Start Umbrel on boot
   config.vm.provision "shell", run: 'always', inline: <<-SHELL
     cd /vagrant/getumbrel/umbrel
-      sudo chown -R 1000:1000 .
-      chmod -R 700 tor/data/*
-    ./scripts/start
+    # This is needed to avoid Tor permission issues on startup
+    sudo rm -rf ./tor/data/*
+    sudo ./scripts/start
   SHELL
 
   # Message

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -22,20 +22,27 @@ umbrelLogo = <<-TEXT
 TEXT
 
 Vagrant.configure(2) do |config|
-  # Install required plugins
-  config.vagrant.plugins = {"vagrant-vbguest" => {"version" => "0.24.0"}}
 
   # Setup VM
   config.vm.define "umbrel-dev"
-  config.vm.box = "debian/buster64"
+  config.vm.box = "bento/debian-10"
   config.vm.hostname = "umbrel-dev"
   config.vm.network "public_network", bridge: "en0: Wi-Fi (AirPort)"
-  config.vm.synced_folder ".", "/vagrant", type: "virtualbox"
+  config.vm.synced_folder ".", "/vagrant"
 
   # Configure VM resources
-  config.vm.provider "virtualbox" do |vb|
+  config.vm.provider "virtualbox" do |vb, override|
+    # Install required plugins
+    # config.vagrant.plugins = {"vagrant-vbguest" => {"version" => "0.24.0"}}
+    # config.vm.synced_folder ".", "/vagrant", type: "virtualbox"
+
     vb.customize ["modifyvm", :id, "--cpus", "2"]
     vb.customize ["modifyvm", :id, "--memory", "2048"]
+  end
+
+  config.vm.provider "parallels" do |prl|
+    prl.cpus = 2
+    prl.memory = 2048
   end
 
   # Update package lists
@@ -68,8 +75,8 @@ Vagrant.configure(2) do |config|
   # Start Umbrel on boot
   config.vm.provision "shell", run: 'always', inline: <<-SHELL
     cd /vagrant/getumbrel/umbrel
-    sudo chown -R 1000:1000 .
-    chmod -R 700 tor/data/*
+      sudo chown -R 1000:1000 .
+      chmod -R 700 tor/data/*
     ./scripts/start
   SHELL
 

--- a/umbrel-dev
+++ b/umbrel-dev
@@ -40,14 +40,14 @@ fi
 # Check required dependencies are installed
 # If not, fail with instructions on how to fix
 check_dependencies() {
-  for cmd in "git" "vagrant" "vboxmanage"; do
+  for cmd in "git" "vagrant" "prlctl"; do
     if ! command -v $cmd >/dev/null 2>&1; then
-      echo "This script requires Git, VirtualBox and Vagrant to be installed."
+      echo "This script requires Git, Vagrant and Parallels to be installed."
       echo
       echo "If you use Homebrew you can install them with:"
       echo
       echo "  brew install git"
-      echo "  brew install --cask virtualbox vagrant"
+      echo "  brew install --cask vagrant parallels"
       echo
       echo "Otherwise see:"
       echo
@@ -110,7 +110,8 @@ if [[ "$command" = "init" ]]; then
   cp "$(get_script_location)/Vagrantfile" .
 
   echo
-  vagrant plugin install --local vagrant-vbguest --plugin-version=0.24.0
+  vagrant plugin install --local vagrant-parallels
+  vagrant plugin install --local vagrant-sshfs
 
   echo
   echo "Cloning container repositories..."
@@ -138,13 +139,6 @@ fi
 # Boot the development VM
 if [[ "$command" = "boot" ]]; then
   check_umbrel_dev_environment
-
-  # Update some packages on boot to prevent issues with vagrant-vbguest.
-  # https://github.com/dotless-de/vagrant-vbguest/issues/351#issuecomment-545391139
-  vagrant up --no-provision || true # This will sometimes fail
-  vagrant ssh -c "sudo apt-get update -y && sudo apt-get install -y build-essential linux-headers-amd64 linux-image-amd64 python-pip"
-  vagrant halt
-
   vagrant up
   exit
 fi


### PR DESCRIPTION
This branch drops VirtualBox in favour of Parallels as the virtualisation backend since Parallels runs on both Intel and Apple silicon Macs.

We also switch to using SSHFS to implement fielsystem sharing between the host and VM instead of Parallels built in folder sharing. I'm not sure why but Parallels built in folder sharing causes loads of [permission issues](https://github.com/lightningnetwork/lnd/issues/3612#issuecomment-957181129). For whatever reason SSHFS works well, at the cost of increased CPU usage and worse fs performance.

`chown` currently fails inside the guest on the SSHFS mount, which means containers that use `chown` will also fail. This might be resolvable by passing some options to SSHFS to give the guest complete control over the host fs.