### PR TITLE
Multiarch support

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -32,12 +32,7 @@ Vagrant.configure(2) do |config|
   config.vm.define "umbrel-dev"
   config.vm.box = ENV["ARCH"].include?("x86") ? "debian/buster64" : "avi0xff/debian10-arm64"
   config.vm.hostname = "umbrel-dev"
-  config.vm.network "public_network", bridge: [
-    "en0: Wi-Fi",
-    "en1: Wi-Fi",
-    "en0: Wi-Fi 2",
-    "en1: Wi-Fi 2",
-  ]
+  config.vm.network "public_network", bridge: "en0: Wi-Fi"
   # Private network needed for NFS share
   config.vm.network "private_network", ip: "192.168.56.56"
 

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -88,8 +88,6 @@ Vagrant.configure(2) do |config|
   # Start Umbrel on boot
   config.vm.provision "shell", run: 'always', inline: <<-SHELL
     cd /vagrant/getumbrel/umbrel
-    sudo chown -R 1000:1000 .
-    chmod -R 700 tor/data/*
     ./scripts/start
   SHELL
 

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -29,7 +29,12 @@ Vagrant.configure(2) do |config|
   config.vm.define "umbrel-dev"
   config.vm.box = "debian/buster64"
   config.vm.hostname = "umbrel-dev"
-  config.vm.network "public_network", bridge: "en0: Wi-Fi (AirPort)"
+  config.vm.network "public_network", bridge: [
+    "en0: Wi-Fi",
+    "en1: Wi-Fi",
+    "en0: Wi-Fi 2",
+    "en1: Wi-Fi 2",
+  ]
   # Private network needed for NFS share
   config.vm.network "private_network", ip: "192.168.56.56"
 

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -25,9 +25,12 @@ Vagrant.configure(2) do |config|
   # Install required plugins
   config.vagrant.plugins = {"vagrant-vbguest" => {"version" => "0.24.0"}}
 
+  CORES = 4
+  MEMORY = 4096
+
   # Setup VM
   config.vm.define "umbrel-dev"
-  config.vm.box = "debian/buster64"
+  config.vm.box = ENV["ARCH"].include?("x86") ? "debian/buster64" : "avi0xff/debian10-arm64"
   config.vm.hostname = "umbrel-dev"
   config.vm.network "public_network", bridge: [
     "en0: Wi-Fi",
@@ -57,10 +60,16 @@ Vagrant.configure(2) do |config|
   }
   config.bindfs.bind_folder "/code", "/vagrant"
 
-  # Configure VM resources
+  # VirtualBox config.
   config.vm.provider "virtualbox" do |vb|
-    vb.customize ["modifyvm", :id, "--cpus", "2"]
-    vb.customize ["modifyvm", :id, "--memory", "2048"]
+    vb.customize ["modifyvm", :id, "--cpus", CORES]
+    vb.customize ["modifyvm", :id, "--memory", MEMORY]
+  end
+
+  # Parallels config.
+  config.vm.provider "parallels" do |parallels|
+    parallels.cpus = CORES
+    parallels.memory = MEMORY
   end
 
   # Update package lists

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -46,7 +46,7 @@ Vagrant.configure(2) do |config|
   config.bindfs.default_options = {
     force_user: 'vagrant',
     force_group: 'vagrant',
-    # Everything is bound to vagrant:vagrant and Umbrel will chown from time to time
+    # Everything is owned by vagrant:vagrant and Umbrel will chown from time to time
     # Causing an operation not permitted error, this ignores that error
     o: 'chown-ignore'
   }

--- a/umbrel-dev
+++ b/umbrel-dev
@@ -37,17 +37,43 @@ if [[ "$(uname)" == "Darwin" ]]; then
   gnused=gsed
 fi
 
+determine_provider() {
+  local -r arch=$(uname -m)
+  if [[ "${OSTYPE}" == *"darwin"* ]]; then
+    if [[ "${arch}" == *"x86"* ]]; then
+      echo "virtualbox"
+    else
+      echo "parallels"
+    fi
+  else
+    echo "virtualbox"
+  fi
+}
+
 # Check required dependencies are installed
 # If not, fail with instructions on how to fix
 check_dependencies() {
-  for cmd in "git" "vagrant" "vboxmanage"; do
+  local deps
+
+  if [[ "${PROVIDER}" == "virtualbox" ]]; then
+    deps=("git" "vagrant" "vboxmanage")
+  elif [[ "${PROVIDER}" == "parallels" ]]; then
+    deps=("git" "vagrant" "prlctl")
+  fi
+
+  # To install virtualbox
+  # brew install --cask vagrant virtualbox
+
+  # To install parallels
+  # brew install --cask vagrant parallels
+
+  for cmd in "${deps[@]}"; do
     if ! command -v $cmd >/dev/null 2>&1; then
-      echo "This script requires Git, VirtualBox and Vagrant to be installed."
+      echo "  Command is missing: ${cmd}"
       echo
-      echo "If you use Homebrew you can install them with:"
+      echo "  To continue, please install the command: ${cmd}"
       echo
-      echo "  brew install git"
-      echo "  brew install --cask virtualbox vagrant"
+      echo "  e.g. brew install git"
       echo
       echo "Otherwise see:"
       echo
@@ -90,6 +116,8 @@ check_umbrel_dev_environment() {
   done
 }
 
+PROVIDER="${UMBREL_DEV_PROVIDER:-$(determine_provider)}"
+
 # Check deps before running any commands
 check_dependencies
 
@@ -110,7 +138,13 @@ if [[ "$command" = "init" ]]; then
   cp "$(get_script_location)/Vagrantfile" .
 
   echo
-  vagrant plugin install --local vagrant-vbguest --plugin-version=0.24.0
+
+  if [[ "${PROVIDER}" == "virtualbox" ]]; then
+    vagrant plugin install --local vagrant-vbguest --plugin-version=0.24.0
+  elif [[ "${PROVIDER}" == "parallels" ]]; then
+    vagrant plugin install --local vagrant-parallels
+  fi
+  
   vagrant plugin install vagrant-bindfs
 
   echo
@@ -140,13 +174,17 @@ fi
 if [[ "$command" = "boot" ]]; then
   check_umbrel_dev_environment
 
-  # Update some packages on boot to prevent issues with vagrant-vbguest.
-  # https://github.com/dotless-de/vagrant-vbguest/issues/351#issuecomment-545391139
-  vagrant up --no-provision || true # This will sometimes fail
-  vagrant ssh -c "sudo apt-get update -y && sudo apt-get install -y build-essential linux-headers-amd64 linux-image-amd64 python-pip"
-  vagrant halt
+  export ARCH="${UMBREL_DEV_ARCH:-$(uname -m)}"
 
-  vagrant up
+  if [[ "${PROVIDER}" == "virtualbox" ]]; then
+    # Update some packages on boot to prevent issues with vagrant-vbguest.
+    # https://github.com/dotless-de/vagrant-vbguest/issues/351#issuecomment-545391139
+    vagrant up --no-provision --provider "${PROVIDER}" || true # This will sometimes fail
+    vagrant ssh -c "sudo apt-get update -y && sudo apt-get install -y build-essential linux-headers-amd64 linux-image-amd64 python-pip"
+    vagrant halt
+  fi
+
+  vagrant up --provider "${PROVIDER}"
   exit
 fi
 

--- a/umbrel-dev
+++ b/umbrel-dev
@@ -193,6 +193,9 @@ fi
 # Shutdown the development VM
 if [[ "$command" = "shutdown" ]]; then
   check_umbrel_dev_environment
+
+  run_in_vm "sudo scripts/stop"
+  
   vagrant halt
   exit
 fi

--- a/umbrel-dev
+++ b/umbrel-dev
@@ -176,12 +176,14 @@ if [[ "$command" = "boot" ]]; then
 
   export ARCH="${UMBREL_DEV_ARCH:-$(uname -m)}"
 
-  if [[ "${PROVIDER}" == "virtualbox" ]]; then
+  if [[ "${PROVIDER}" == "virtualbox" ]] && [[ ! -f ".umbrel-virtualbox-setup" ]]; then
     # Update some packages on boot to prevent issues with vagrant-vbguest.
     # https://github.com/dotless-de/vagrant-vbguest/issues/351#issuecomment-545391139
     vagrant up --no-provision --provider "${PROVIDER}" || true # This will sometimes fail
     vagrant ssh -c "sudo apt-get update -y && sudo apt-get install -y build-essential linux-headers-amd64 linux-image-amd64 python-pip"
     vagrant halt
+
+    touch .umbrel-virtualbox-setup
   fi
 
   vagrant up --provider "${PROVIDER}"

--- a/umbrel-dev
+++ b/umbrel-dev
@@ -194,8 +194,8 @@ fi
 if [[ "$command" = "shutdown" ]]; then
   check_umbrel_dev_environment
 
-  run_in_vm "sudo scripts/stop"
-  
+  run_in_vm "sudo scripts/stop || true"
+
   vagrant halt
   exit
 fi

--- a/umbrel-dev
+++ b/umbrel-dev
@@ -111,6 +111,7 @@ if [[ "$command" = "init" ]]; then
 
   echo
   vagrant plugin install --local vagrant-vbguest --plugin-version=0.24.0
+  vagrant plugin install vagrant-bindfs
 
   echo
   echo "Cloning container repositories..."


### PR DESCRIPTION
This branch adds multiarch support by using `parallels` for virtualisation on M1 Macs. All other platforms continue to use `virtualbox`. It uses NFS for the file share in attempt to resolve permission issues using the `virtualbox` shared folder driver.

It automatically detects the vagrant provider that should be used by checking OS and arch. You can override this detection by setting the env. var. `UMBREL_DEV_PROVIDER`.
eg. `UMBREL_DEV_PROVIDER=parallels umbrel-dev boot`