### PR TITLE
Vagrant fixes

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -72,7 +72,7 @@ Vagrant.configure(2) do |config|
 
   # Install Docker
   config.vm.provision "shell", inline: <<-SHELL
-    sudo apt-get install -y build-essential libssl-dev curl python3-pip libffi-dev python-dev
+    sudo apt-get install -y curl python3-pip libffi-dev
     curl -fsSL https://get.docker.com | sudo sh
     sudo usermod -aG docker vagrant
     pip3 install -U "bcrypt<4.0.0"

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -72,15 +72,22 @@ Vagrant.configure(2) do |config|
 
   # Install Docker
   config.vm.provision "shell", inline: <<-SHELL
-    sudo apt-get install -y curl python3-pip libffi-dev
+    sudo apt-get install -y build-essential libssl-dev curl python3-pip libffi-dev python-dev
     curl -fsSL https://get.docker.com | sudo sh
     sudo usermod -aG docker vagrant
+    pip3 install -U "bcrypt<4.0.0"
     pip3 install docker-compose
   SHELL
 
   # Install Avahi
   config.vm.provision "shell", inline: <<-SHELL
     apt-get install -y avahi-daemon avahi-discover libnss-mdns
+  SHELL
+
+  # Install yq
+  config.vm.provision "shell", inline: <<-SHELL
+    wget https://github.com/mikefarah/yq/releases/download/${VERSION}/${BINARY}.tar.gz -O - |\
+    tar xz && mv ${BINARY} /usr/bin/yq
   SHELL
 
   # Install Umbrel


### PR DESCRIPTION
umbrel-dev failed to boot on mac os for two reasons:
  - bcrypt latest version [does not work](https://github.com/adriankumpf/teslamate/discussions/2881#discussioncomment-3786381). (fixes https://github.com/getumbrel/umbrel-dev/issues/25) 
  - yq seems to be a new dependency and is logging this error:

      ```text
    umbrel-dev: Creating umbrel_middleware_1 ... done
    umbrel-dev: Creating manager             ... done
    umbrel-dev: Creating nginx               ...
    umbrel-dev: Creating nginx               ... done
    umbrel-dev: 
    umbrel-dev: Removing status server iptables entry...
    umbrel-dev: Exiting iptables setup when not on Umbrel OS
    umbrel-dev: 
    umbrel-dev: Starting installed apps...
    umbrel-dev: 
    umbrel-dev: This script requires "yq" to be installed
    The SSH command responded with a non-zero exit status. Vagrant
    assumes that this means the command failed. The output for this command
    should be in the log above. Please read the output to determine what
    went wrong.
    ```
    As you see its pulling the latest version of `yq`, not sure if you want to lock into a specific one?